### PR TITLE
Add ability to run notebook on binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# covid-19
+A collection of work related to COVID-19
+
+You can run the Jupyter notebooks right now on the Cloud by clicking this button:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/k-sys/covid-19/master?urlpath=git-pull?repo=https://github.com/k-sys/covid-19)

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,9 @@
+channels:
+  - conda-forge
+dependencies:
+  - ipython
+  - matplotlib
+  - numpy
+  - pandas
+  - scipy
+  - nbgitpuller

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+jupyter serverextension enable --py nbgitpuller --sys-prefix

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,1 @@
-jupyter serverextension enable --py nbgitpuller --sys-prefix
+jupyter serverextension enable nbgitpuller --sys-prefix

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,0 @@
-jupyter serverextension enable nbgitpuller --sys-prefix


### PR DESCRIPTION
I created a binder subdir with the environment.yml file, which will allow binder to build the environment and launch it on the Cloud. 

I also added a README.md with the binder button