### PR TITLE
Environment file for Binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+name: covid
+channels:
+  - anaconda
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.6  # latest version supported by Theano
+  - jupyter
+  - notebook
+  - mkl
+  - mkl-service
+  - pymc3
+  - pandas
+  - theano
+  - numpy
+  - scipy
+  - graphviz
+  - seaborn
+  - pydot
+  - matplotlib
+  - arviz
+  - watermark
+  - requests


### PR DESCRIPTION
Hi there, it's nice to see that the repo has had such a great reach!
This PR has a small addition to the repo that could help to make the content more accessible for people (in terms of setup).  It can be painful to set up environments for PyMC3 and Theano on local machines, but **[Binder](https://mybinder.readthedocs.io/en/latest/)** provides a place to make public repos more interactive online.

My addition is an **`environment.yml` file** which can be used to run the notebooks in Binder.

Here is the [Binder link](https://mybinder.org/v2/gh/mfarragher/covid-19/environ) for my branch - Binder has built the Docker image for the environment on that branch, so the notebooks can be run online there.

Binder is quite slow today for some reason, but usually I find it so handy for sharing interactive notebooks and making output more reproducible.  I've linked up a few of my repos to Binder so feel free to explore those.